### PR TITLE
Web3 connection

### DIFF
--- a/lib/contract_interact/ether.js
+++ b/lib/contract_interact/ether.js
@@ -21,7 +21,6 @@ const rootPrefix = '../..'
   , basicHelper = require(rootPrefix + '/helpers/basic_helper')
   , coreConstants = require(rootPrefix + '/config/core_constants')
   , VC_GAS_PRICE = coreConstants.OST_VALUE_GAS_PRICE
-  , VC_GAS_LIMIT = 30000 //coreConstants.OST_VALUE_GAS_LIMIT
 ;
 
 /**

--- a/lib/web3/providers/utility_rpc.js
+++ b/lib/web3/providers/utility_rpc.js
@@ -12,12 +12,12 @@ const OSTBase = require("@openstfoundation/openst-base")
 
 const rootPrefix = '../../..'
   , coreConstants = require(rootPrefix + '/config/core_constants')
-  , OstWeb3 = OSTBase.OstWeb3Pool
+  , OstWeb3Pool = OSTBase.OstWeb3Pool
 ;
 
 Object.defineProperty(module, 'exports', {
   get: function () {
-    let web3UtilityRpcProvider = OstWeb3.Factory.getWeb3(coreConstants.OST_UTILITY_GETH_RPC_PROVIDER);
+    let web3UtilityRpcProvider = OstWeb3Pool.Factory.getWeb3(coreConstants.OST_UTILITY_GETH_RPC_PROVIDER);
     web3UtilityRpcProvider.chainId = coreConstants.OST_UTILITY_CHAIN_ID;
     web3UtilityRpcProvider.chainKind = 'utility';
 

--- a/lib/web3/providers/utility_rpc.js
+++ b/lib/web3/providers/utility_rpc.js
@@ -7,16 +7,20 @@
  *
  */
 
-const OSTBase = require("@openstfoundation/openst-base");
+const OSTBase = require("@openstfoundation/openst-base")
+;
 
 const rootPrefix = '../../..'
   , coreConstants = require(rootPrefix + '/config/core_constants')
-  , OstWeb3 = OSTBase.OstWeb3
+  , OstWeb3 = OSTBase.OstWeb3Pool
 ;
 
-const web3UtilityRpcProvider = new OstWeb3(coreConstants.OST_UTILITY_GETH_RPC_PROVIDER);
+Object.defineProperty(module, 'exports', {
+  get: function () {
+    let web3UtilityRpcProvider = OstWeb3.Factory.getWeb3(coreConstants.OST_UTILITY_GETH_RPC_PROVIDER);
+    web3UtilityRpcProvider.chainId = coreConstants.OST_UTILITY_CHAIN_ID;
+    web3UtilityRpcProvider.chainKind = 'utility';
 
-web3UtilityRpcProvider.chainId = coreConstants.OST_UTILITY_CHAIN_ID;
-web3UtilityRpcProvider.chainKind = 'utility';
-
-module.exports = web3UtilityRpcProvider;
+    return web3UtilityRpcProvider;
+  }
+});

--- a/lib/web3/providers/utility_ws.js
+++ b/lib/web3/providers/utility_ws.js
@@ -12,12 +12,12 @@ const OSTBase = require("@openstfoundation/openst-base")
 
 const rootPrefix = '../../..'
   , coreConstants = require(rootPrefix + '/config/core_constants')
-  , OstWeb3 = OSTBase.OstWeb3Pool
+  , OstWeb3Pool = OSTBase.OstWeb3Pool
 ;
 
 Object.defineProperty(module, 'exports', {
   get: function () {
-    let web3UtilityWsProvider = OstWeb3.Factory.getWeb3(coreConstants.OST_UTILITY_GETH_WS_PROVIDER);
+    let web3UtilityWsProvider = OstWeb3Pool.Factory.getWeb3(coreConstants.OST_UTILITY_GETH_WS_PROVIDER);
     web3UtilityWsProvider.chainId = coreConstants.OST_UTILITY_CHAIN_ID;
     web3UtilityWsProvider.chainKind = 'utility';
 

--- a/lib/web3/providers/utility_ws.js
+++ b/lib/web3/providers/utility_ws.js
@@ -12,12 +12,15 @@ const OSTBase = require("@openstfoundation/openst-base")
 
 const rootPrefix = '../../..'
   , coreConstants = require(rootPrefix + '/config/core_constants')
-  , OstWeb3 = OSTBase.OstWeb3
+  , OstWeb3 = OSTBase.OstWeb3Pool
 ;
 
-const web3UtilityWsProvider = new OstWeb3(coreConstants.OST_UTILITY_GETH_WS_PROVIDER);
+Object.defineProperty(module, 'exports', {
+  get: function () {
+    let web3UtilityWsProvider = OstWeb3.Factory.getWeb3(coreConstants.OST_UTILITY_GETH_WS_PROVIDER);
+    web3UtilityWsProvider.chainId = coreConstants.OST_UTILITY_CHAIN_ID;
+    web3UtilityWsProvider.chainKind = 'utility';
 
-web3UtilityWsProvider.chainId = coreConstants.OST_UTILITY_CHAIN_ID;
-web3UtilityWsProvider.chainKind = 'utility';
-
-module.exports = web3UtilityWsProvider;
+    return web3UtilityWsProvider;
+  }
+});

--- a/lib/web3/providers/value_rpc.js
+++ b/lib/web3/providers/value_rpc.js
@@ -12,12 +12,15 @@ const OSTBase = require("@openstfoundation/openst-base")
 
 const rootPrefix = '../../..'
   , coreConstants = require(rootPrefix + '/config/core_constants')
-  , OstWeb3 = OSTBase.OstWeb3
+  , OstWeb3 = OSTBase.OstWeb3Pool
 ;
 
-const web3ValueRpcProvider = new OstWeb3(coreConstants.OST_VALUE_GETH_RPC_PROVIDER);
+Object.defineProperty(module, 'exports', {
+  get: function () {
+    let web3ValueRpcProvider = OstWeb3.Factory.getWeb3(coreConstants.OST_VALUE_GETH_RPC_PROVIDER);
+    web3ValueRpcProvider.chainId = coreConstants.OST_VALUE_CHAIN_ID;
+    web3ValueRpcProvider.chainKind = 'value';
 
-web3ValueRpcProvider.chainId = coreConstants.OST_VALUE_CHAIN_ID;
-web3ValueRpcProvider.chainKind = 'value';
-
-module.exports = web3ValueRpcProvider;
+    return web3ValueRpcProvider;
+  }
+});

--- a/lib/web3/providers/value_rpc.js
+++ b/lib/web3/providers/value_rpc.js
@@ -12,12 +12,12 @@ const OSTBase = require("@openstfoundation/openst-base")
 
 const rootPrefix = '../../..'
   , coreConstants = require(rootPrefix + '/config/core_constants')
-  , OstWeb3 = OSTBase.OstWeb3Pool
+  , OstWeb3Pool = OSTBase.OstWeb3Pool
 ;
 
 Object.defineProperty(module, 'exports', {
   get: function () {
-    let web3ValueRpcProvider = OstWeb3.Factory.getWeb3(coreConstants.OST_VALUE_GETH_RPC_PROVIDER);
+    let web3ValueRpcProvider = OstWeb3Pool.Factory.getWeb3(coreConstants.OST_VALUE_GETH_RPC_PROVIDER);
     web3ValueRpcProvider.chainId = coreConstants.OST_VALUE_CHAIN_ID;
     web3ValueRpcProvider.chainKind = 'value';
 

--- a/lib/web3/providers/value_ws.js
+++ b/lib/web3/providers/value_ws.js
@@ -12,12 +12,15 @@ const OSTBase = require("@openstfoundation/openst-base")
 
 const rootPrefix = '../../..'
   , coreConstants = require(rootPrefix + '/config/core_constants')
-  , OstWeb3 = OSTBase.OstWeb3
+  , OstWeb3 = OSTBase.OstWeb3Pool
 ;
 
-const web3ValueWsProvider = new OstWeb3(coreConstants.OST_VALUE_GETH_WS_PROVIDER);
+Object.defineProperty(module, 'exports', {
+  get: function () {
+    let web3ValueWsProvider = OstWeb3.Factory.getWeb3(coreConstants.OST_VALUE_GETH_WS_PROVIDER);
+    web3ValueWsProvider.chainId = coreConstants.OST_VALUE_CHAIN_ID;
+    web3ValueWsProvider.chainKind = 'value';
 
-web3ValueWsProvider.chainId = coreConstants.OST_VALUE_CHAIN_ID;
-web3ValueWsProvider.chainKind = 'value';
-
-module.exports = web3ValueWsProvider;
+    return web3ValueWsProvider;
+  }
+});

--- a/lib/web3/providers/value_ws.js
+++ b/lib/web3/providers/value_ws.js
@@ -12,12 +12,12 @@ const OSTBase = require("@openstfoundation/openst-base")
 
 const rootPrefix = '../../..'
   , coreConstants = require(rootPrefix + '/config/core_constants')
-  , OstWeb3 = OSTBase.OstWeb3Pool
+  , OstWeb3Pool = OSTBase.OstWeb3Pool
 ;
 
 Object.defineProperty(module, 'exports', {
   get: function () {
-    let web3ValueWsProvider = OstWeb3.Factory.getWeb3(coreConstants.OST_VALUE_GETH_WS_PROVIDER);
+    let web3ValueWsProvider = OstWeb3Pool.Factory.getWeb3(coreConstants.OST_VALUE_GETH_WS_PROVIDER);
     web3ValueWsProvider.chainId = coreConstants.OST_VALUE_CHAIN_ID;
     web3ValueWsProvider.chainKind = 'value';
 

--- a/services/utils/generate_address.js
+++ b/services/utils/generate_address.js
@@ -9,7 +9,6 @@
 const rootPrefix = '../..'
   , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
   , responseHelper = require(rootPrefix + '/lib/formatter/response')
-  , logger = require(rootPrefix + '/helpers/custom_console_logger')
   , basicHelper = require(rootPrefix + '/helpers/basic_helper')
 ;
 

--- a/test/services/balance_branded_token.js
+++ b/test/services/balance_branded_token.js
@@ -9,7 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.balance
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
   , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
   , brandedTokenConfig = require(brandedTokenConfigPath)
 ;

--- a/test/services/balance_simple_token.js
+++ b/test/services/balance_simple_token.js
@@ -9,9 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.balance
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
-  , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
-  , brandedTokenConfig = require(brandedTokenConfigPath)
 ;
 
 var testValidData = {

--- a/test/services/balance_simple_token_prime.js
+++ b/test/services/balance_simple_token_prime.js
@@ -9,9 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.balance
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
-  , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
-  , brandedTokenConfig = require(brandedTokenConfigPath)
 ;
 
 var testValidData = {

--- a/test/services/transaction_get_receipt.js
+++ b/test/services/transaction_get_receipt.js
@@ -9,9 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.transaction
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
-  , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
-  , brandedTokenConfig = require(brandedTokenConfigPath)
 ;
 
 var testValidData = {

--- a/test/services/transaction_transfer_branded_token.js
+++ b/test/services/transaction_transfer_branded_token.js
@@ -9,7 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.transaction.transfer
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
   , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
   , brandedTokenConfig = require(brandedTokenConfigPath)
 ;

--- a/test/services/transaction_transfer_eth.js
+++ b/test/services/transaction_transfer_eth.js
@@ -9,9 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.transaction.transfer
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
-  , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
-  , brandedTokenConfig = require(brandedTokenConfigPath)
 ;
 
 var testValidData = {

--- a/test/services/transaction_transfer_simple_token.js
+++ b/test/services/transaction_transfer_simple_token.js
@@ -9,9 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.transaction.transfer
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
-  , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
-  , brandedTokenConfig = require(brandedTokenConfigPath)
 ;
 
 var testValidData = {

--- a/test/services/transaction_transfer_simple_token_prime.js
+++ b/test/services/transaction_transfer_simple_token_prime.js
@@ -9,9 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.transaction.transfer
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
-  , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
-  , brandedTokenConfig = require(brandedTokenConfigPath)
 ;
 
 var testValidData = {

--- a/test/services/utils_get_branded_token_details.js
+++ b/test/services/utils_get_branded_token_details.js
@@ -9,7 +9,6 @@ const chai = require('chai')
 const rootPrefix = "../.."
   , openstPlatform = require(rootPrefix + '/index')
   , platformServices = openstPlatform.services.utils
-  , web3ProviderFactory = require(rootPrefix + '/lib/web3/providers/factory')
   , brandedTokenConfigPath = os.homedir() + "/openst-setup/branded_tokens.json"
   , brandedTokenConfig = require(brandedTokenConfigPath)
 ;


### PR DESCRIPTION
web3 connection pooling is required to interact with geth. We can use one connection from several instances which are available in pool. So even if one connection is engage we can use another and will save time. So, That is done using Object.defineProperty().

This is in regard with #148 